### PR TITLE
Browse in Hubmenu changed to More Services

### DIFF
--- a/Instructions/10979C_LAB_AK_01.md
+++ b/Instructions/10979C_LAB_AK_01.md
@@ -17,7 +17,7 @@
 4.   If the  **Hub** menu is not expanded, click the **Show** menu icon directly underneath the **Microsoft Azure** label in the upper-left corner to expand the **Hub** menu.
 5.   On the  **Hub** menu, click **+New**.
 6.   In the  **New** blade, review the list of available options, but do not select any.
-7.   In the  **Hub** menu, click **Browse** and then, in the list of entries, click **Subscriptions**.
+7.   In the  **Hub** menu, click **More Services** and then, in the list of entries, click **Subscriptions**.
 8.   In the  **Subscriptions** blade, right-click the entry that represents your subscription, and then click **Pin to dashboard** from the context menu.
 9.   Click the  **Notification** icon (bell) in the horizontal bar in the upper-right part of the portal page, and then verify that the subscription tile was pinned to dashboard successfully.
 10.   Click  **Microsoft Azure** in the upper-left corner to return to the dashboard.


### PR DESCRIPTION
The browse option in the hubmenu is recently changed into 'More Services'
This is for all modules in this course.