### PR TITLE
New VM disk type option (HDD/SSD) while creating VM

### DIFF
--- a/Instructions/10979C_LAB_03.md
+++ b/Instructions/10979C_LAB_03.md
@@ -57,6 +57,8 @@ The main tasks for this exercise are as follows:
 2.   From the Azure Portal, create a new VM by using the Windows Server 2012 R2 Datacenter Marketplace image and Resource Manager deployment model with the following settings:
   -   Name:  **labvm1**
 
+  -   VM disk type:  **HDD**
+
   -   User name:  **Student**
 
   -   Password:  **Pa$$w0rd1234**


### PR DESCRIPTION
New VM disk type option while creating VM. Options HDD or SSD.

The option later in the labs: select standard can be remove. 

This is for all modules in the course where you create a VM in the portal.